### PR TITLE
Removed doc.install from Formula

### DIFF
--- a/Formula/mmseqs.rb
+++ b/Formula/mmseqs.rb
@@ -18,7 +18,6 @@ class Mmseqs < Formula
     system "make"
 
     bin.install "src/mmseqs"
-    doc.install "userguide.pdf"
     bash_completion.install "util/bash-completion.sh" => "mmseqs.sh"
   end
 


### PR DESCRIPTION
Since the documentation was moved to the wiki the installation using brew fails when `doc.install "userguide.pdf"`