### PR TITLE
Remove leading space from convertmsa database output

### DIFF
--- a/src/util/convertmsa.cpp
+++ b/src/util/convertmsa.cpp
@@ -60,7 +60,6 @@ int convertmsa(int argc, const char **argv, const Command &command) {
                 result.append(">");
                 if (j == 0) {
                     result.append(identifier);
-                    result.append(" ");
                 }
                 result.append(accession);
                 result.append("\n");

--- a/src/util/convertmsa.cpp
+++ b/src/util/convertmsa.cpp
@@ -51,6 +51,10 @@ int convertmsa(int argc, const char **argv, const Command &command) {
         }
 
         if (inEntry == true  && line == "//") {
+            if (identifier.empty()) {
+                Debug(Debug::ERROR) << "Invalid MSA identifier specified!\n";
+                EXIT(EXIT_FAILURE);
+            }
             inEntry = false;
             result.clear();
             size_t j = 0;
@@ -60,6 +64,7 @@ int convertmsa(int argc, const char **argv, const Command &command) {
                 result.append(">");
                 if (j == 0) {
                     result.append(identifier);
+                    result.append(" ");
                 }
                 result.append(accession);
                 result.append("\n");


### PR DESCRIPTION
As I mentioned briefly in Issue #94 when I ran `convertmsa`, to generate an msa database from an input stockholm formatted alignment, the output database had a leading space after the `>` character on the first line, which then caused `msa2profile` to output various "Invalid" messages.

Removing the leading space as applied in the pull request seems to fix this issue. I don't think my input stockholm format alignment was the cause, since I tried generating this with 2 independent tools. 
However, I am not familiar with either file format and I may easily have overlooked something; also I am not a C++ programmer and I did't try testing this change on any unit tests, so I hope it does not break anything else!

Here's a full example (I can also provide the `TEST.sth` input data if required) and let me know if more details are needed, thank you!

Edit: I am running this on Arch Linux.

```
$ mmseqs convertmsa TEST.sth TEST.db
Program call:
TEST.sth TEST.db 

MMseqs Version: 	11ef9eb2c1dfbdb4c661df80e1b0314207f6da46
Identifier Field	1
Verbosity       	3

Time for merging files: 0 h 0 m 0 s

Done.
$ head -n 2 TEST.db
> db-CARD.1.1.3_geneId-AAA22081.1_desc-cat_annot-ARO3002670_taxaName-Agrobacterium.tumefaciens.str..C58_taxaId-176299
MENYFESPFRGITLDKQVKSPNLVVGKYSYYSGYYHGHSFEDCARYLLPDE-GADRLVIGSFCSIGSGAAFIMAGNQGHRNEWISTFPFFFMPEVPEFENAANGYLPAGDTVIGNDVWIGSEAIIMPGITVGDGAVIGTRALVTKDVEPYAIVGGNPAKTIRKRFDDDSIALLLEMKWWGWPAERLKAAMPLMTSGNVAALYRFWRSDSL----------
$ mmseqs msa2profile TEST.db TEST.profile --match-mode 1 --msa-type 2 --threads 1
Program call:
TEST.db TEST.profile --match-mode 1 --msa-type 2 --threads 1 

MMseqs Version:                    	1944b9783e5a01e722bd519c9792f006aa180b8d
MSA type                           	2
Sub Matrix                         	blosum62.out
Match mode                         	1
Match ratio                        	0.5
Pseudo count a                     	0
Pseudo count b                     	1.5
Compositional bias                 	1
Use global sequence weighting      	false
Filter MSA                         	1
Minimum coverage                   	0
Minimum seq. id.                   	0
Minimum score per column           	-20
Maximum sequence identity threshold	0.9
Select n most diverse seqs         	1000
Threads                            	1
Verbosity                          	3

Finding maximum sequence length and set size.
Compute profiles from MSAs.
Invalid fasta sequence 0 in entry 0!
Invalid msa 0! Skipping entry.
Time for merging files: 0 h 0 m 0 s
Time for merging files: 0 h 0 m 0 s
Time for merging files: 0 h 0 m 0 s
Time for merging files: 0 h 0 m 1 s
Time for processing: 0 h 0 m 2s
```