### PR TITLE
Clarify --cluster-reassign usage

### DIFF
--- a/src/MMseqsBase.cpp
+++ b/src/MMseqsBase.cpp
@@ -253,7 +253,7 @@ std::vector<Command> baseCommands = {
                 "# Cascaded clustering with reassignment\n"
                 "# - Corrects criteria-violoations of cascaded merging\n"
                 "# - Produces more clusters and is a bit slower\n"
-                "mmseqs cluster sequenceDB clusterDB tmp --cluster-reassign\n",
+                "mmseqs cluster sequenceDB clusterDB tmp --cluster-reassign 1\n",
                 "Martin Steinegger <martin.steinegger@mpibpc.mpg.de> & Lars von den Driesch",
                 "<i:sequenceDB> <o:clusterDB> <tmpDir>",
                 CITATION_LINCLUST|CITATION_MMSEQS1|CITATION_MMSEQS2, {{"sequenceDB", DbType::ACCESS_MODE_INPUT, DbType::NEED_DATA, &DbValidator::sequenceDb },


### PR DESCRIPTION
Maybe this is by design, but the (helpful) message about `--cluster-reassign` makes it seem like a flag as opposed to an option, i.e. have to specify `--cluster-reassign 1` to turn it on. Here is a suggestion...

(fwiw I haven't tried this option yet because the install from conda on my machine with my current dataset is giving me an error `Alignment format is not supported!                                ] 0.00% 1 eta - Error: Clustering step 2 died Error: Search died`, but I will investigate more on my end to see if it's an issue with my version/files)