### PR TITLE
Add createdb support for sequence db input

### DIFF
--- a/src/MMseqsBase.cpp
+++ b/src/MMseqsBase.cpp
@@ -124,11 +124,13 @@ std::vector<Command> baseCommands = {
                 "mmseqs createdb file1.fa file2.fa.gz file3.fa sequenceDB\n\n"
                 "# Create a seqDB from stdin\n"
                 "cat seq.fasta | mmseqs createdb stdin sequenceDB\n\n"
+                "# Create a seqDB from another seqDB named inputDB\n"
+                "mmseqs createdb inputDB sequenceDB\n\n"
                 "# Create a seqDB by indexing existing FASTA/Q (for single line fasta entries only)\n"
                 "mmseqs createdb seq.fasta sequenceDB --createdb-mode 1\n",
                 "Martin Steinegger <martin.steinegger@snu.ac.kr>",
-                "<i:fastaFile1[.gz|.bz2]> ... <i:fastaFileN[.gz|.bz2]>|<i:stdin> <o:sequenceDB>",
-                CITATION_MMSEQS2, {{"fast[a|q]File[.gz|bz2]|stdin", DbType::ACCESS_MODE_INPUT, DbType::NEED_DATA | DbType::VARIADIC, &DbValidator::flatfileStdinAndGeneric },
+                "<i:fastaFile1[.gz|.bz2]> ... <i:fastaFileN[.gz|.bz2]>|<i:stdin>|<i:inputDB> <o:sequenceDB>",
+                CITATION_MMSEQS2, {{"fast[a|q]File[.gz|bz2]|stdin|inputDB", DbType::ACCESS_MODE_INPUT, DbType::NEED_DATA | DbType::VARIADIC, &DbValidator::flatfileStdinAndGeneric },
                                                            {"sequenceDB", DbType::ACCESS_MODE_OUTPUT, DbType::NEED_DATA, &DbValidator::flatfile }}},
         {"appenddbtoindex",      appenddbtoindex,      &par.appenddbtoindex,      COMMAND_HIDDEN,
                 NULL,

--- a/src/MMseqsBase.cpp
+++ b/src/MMseqsBase.cpp
@@ -124,7 +124,7 @@ std::vector<Command> baseCommands = {
                 "mmseqs createdb file1.fa file2.fa.gz file3.fa sequenceDB\n\n"
                 "# Create a seqDB from stdin\n"
                 "cat seq.fasta | mmseqs createdb stdin sequenceDB\n\n"
-                "# Create a seqDB from another seqDB named inputDB\n"
+                "# Create a seqDB from generic DB created by tar2db or another seqDB\n"
                 "mmseqs createdb inputDB sequenceDB\n\n"
                 "# Create a seqDB by indexing existing FASTA/Q (for single line fasta entries only)\n"
                 "mmseqs createdb seq.fasta sequenceDB --createdb-mode 1\n",

--- a/src/util/createdb.cpp
+++ b/src/util/createdb.cpp
@@ -98,11 +98,11 @@ int createdb(int argc, const char **argv, const Command& command) {
 
     size_t fileCount = filenames.size();
     DBReader<unsigned int>* reader = NULL;
-    DBReader<unsigned int>* hdrReader = nullptr;
+    DBReader<unsigned int>* hdrReader = NULL;
     if (dbInput == true) {
         reader = new DBReader<unsigned int>(par.db1.c_str(), par.db1Index.c_str(), 1, DBReader<unsigned int>::USE_DATA | DBReader<unsigned int>::USE_INDEX | DBReader<unsigned int>::USE_LOOKUP);
         reader->open(DBReader<unsigned int>::LINEAR_ACCCESS);
-        hdrReader = new DBReader<unsigned int>((par.db1 + "_h").c_str(), (par.db1 + "_h.index").c_str(), 1, DBReader<unsigned int>::USE_DATA | DBReader<unsigned int>::USE_INDEX);
+        hdrReader = new DBReader<unsigned int>(par.hdr1.c_str(), par.hdr1Index.c_str(), 1, DBReader<unsigned int>::USE_DATA | DBReader<unsigned int>::USE_INDEX);
         hdrReader->open(DBReader<unsigned int>::LINEAR_ACCCESS);
         fileCount = reader->getSize();
     }


### PR DESCRIPTION
According to the source code of `createdb`, it should be able to accept MMSeqs databases as one of the input sources. But the current implementation fail to handle MMSeqs db input. This PR fixes this issue.

Probably need to edit `MMSeqsBase.cpp` with new instructions.