### PR TITLE
Remove tmp dir and latest symlink at the end of the easy-workflows

### DIFF
--- a/data/workflow/easycluster.sh
+++ b/data/workflow/easycluster.sh
@@ -64,4 +64,7 @@ if [ -n "${REMOVE_TMP}" ]; then
     "$MMSEQS" rmdb "${TMP_PATH}/clu" ${VERBOSITY_PAR}
     rm -rf "${TMP_PATH}/clu_tmp"
     rm -f "${TMP_PATH}/easycluster.sh"
+    rm -rf "${TMP_PATH}"
+    rm -f "${LATEST}"
+
 fi

--- a/data/workflow/easycluster.sh
+++ b/data/workflow/easycluster.sh
@@ -65,6 +65,7 @@ if [ -n "${REMOVE_TMP}" ]; then
     rm -rf "${TMP_PATH}/clu_tmp"
     rm -f "${TMP_PATH}/easycluster.sh"
     rm -rf "${TMP_PATH}"
-    rm -f "${LATEST}"
-
+    if [ "$(basename "${TMP_PATH}")" = "$(readlink "${LATEST}")" ]; then
+        rm -f "${LATEST}"
+    fi
 fi

--- a/data/workflow/easycluster.sh
+++ b/data/workflow/easycluster.sh
@@ -65,7 +65,4 @@ if [ -n "${REMOVE_TMP}" ]; then
     rm -rf "${TMP_PATH}/clu_tmp"
     rm -f "${TMP_PATH}/easycluster.sh"
     rm -rf "${TMP_PATH}"
-    if [ "$(basename "${TMP_PATH}")" = "$(readlink "${LATEST}")" ]; then
-        rm -f "${LATEST}"
-    fi
 fi

--- a/data/workflow/easyrbh.sh
+++ b/data/workflow/easyrbh.sh
@@ -54,7 +54,4 @@ if [ -n "${REMOVE_TMP}" ]; then
     rm -rf "${TMP_PATH}/rbh_tmp"
     rm -f "${TMP_PATH}/easyrbh.sh"
     rm -rf "${TMP_PATH}"
-    if [ "$(basename "${TMP_PATH}")" = "$(readlink "${LATEST}")" ]; then
-        rm -f "${LATEST}"
-    fi
 fi

--- a/data/workflow/easyrbh.sh
+++ b/data/workflow/easyrbh.sh
@@ -53,4 +53,6 @@ if [ -n "${REMOVE_TMP}" ]; then
     fi
     rm -rf "${TMP_PATH}/rbh_tmp"
     rm -f "${TMP_PATH}/easyrbh.sh"
+    rm -rf "${TMP_PATH}"
+    rm -f "${LATEST}"
 fi

--- a/data/workflow/easyrbh.sh
+++ b/data/workflow/easyrbh.sh
@@ -54,5 +54,7 @@ if [ -n "${REMOVE_TMP}" ]; then
     rm -rf "${TMP_PATH}/rbh_tmp"
     rm -f "${TMP_PATH}/easyrbh.sh"
     rm -rf "${TMP_PATH}"
-    rm -f "${LATEST}"
+    if [ "$(basename "${TMP_PATH}")" = "$(readlink "${LATEST}")" ]; then
+        rm -f "${LATEST}"
+    fi
 fi

--- a/data/workflow/easysearch.sh
+++ b/data/workflow/easysearch.sh
@@ -74,7 +74,4 @@ if [ -n "${REMOVE_TMP}" ]; then
     rm -rf "${TMP_PATH}/search_tmp"
     rm -f "${TMP_PATH}/easysearch.sh"
     rm -rf "${TMP_PATH}"
-    if [ "$(basename "${TMP_PATH}")" = "$(readlink "${LATEST}")" ]; then
-        rm -f "${LATEST}"
-    fi
 fi

--- a/data/workflow/easysearch.sh
+++ b/data/workflow/easysearch.sh
@@ -74,5 +74,7 @@ if [ -n "${REMOVE_TMP}" ]; then
     rm -rf "${TMP_PATH}/search_tmp"
     rm -f "${TMP_PATH}/easysearch.sh"
     rm -rf "${TMP_PATH}"
-    rm -f "${LATEST}"
+    if [ "$(basename "${TMP_PATH}")" = "$(readlink "${LATEST}")" ]; then
+        rm -f "${LATEST}"
+    fi
 fi

--- a/data/workflow/easysearch.sh
+++ b/data/workflow/easysearch.sh
@@ -73,4 +73,6 @@ if [ -n "${REMOVE_TMP}" ]; then
     fi
     rm -rf "${TMP_PATH}/search_tmp"
     rm -f "${TMP_PATH}/easysearch.sh"
+    rm -rf "${TMP_PATH}"
+    rm -f "${LATEST}"
 fi

--- a/data/workflow/easytaxonomy.sh
+++ b/data/workflow/easytaxonomy.sh
@@ -83,5 +83,7 @@ if [ -n "${REMOVE_TMP}" ]; then
     rm -rf "${TMP_PATH}/taxonomy_tmp"
     rm -f "${TMP_PATH}/easytaxonomy.sh"
     rm -rf "${TMP_PATH}"
-    rm -f "${LATEST}"
+    if [ "$(basename "${TMP_PATH}")" = "$(readlink "${LATEST}")" ]; then
+        rm -f "${LATEST}"
+    fi
 fi

--- a/data/workflow/easytaxonomy.sh
+++ b/data/workflow/easytaxonomy.sh
@@ -82,4 +82,6 @@ if [ -n "${REMOVE_TMP}" ]; then
 
     rm -rf "${TMP_PATH}/taxonomy_tmp"
     rm -f "${TMP_PATH}/easytaxonomy.sh"
+    rm -rf "${TMP_PATH}"
+    rm -f "${LATEST}"
 fi

--- a/data/workflow/easytaxonomy.sh
+++ b/data/workflow/easytaxonomy.sh
@@ -83,7 +83,4 @@ if [ -n "${REMOVE_TMP}" ]; then
     rm -rf "${TMP_PATH}/taxonomy_tmp"
     rm -f "${TMP_PATH}/easytaxonomy.sh"
     rm -rf "${TMP_PATH}"
-    if [ "$(basename "${TMP_PATH}")" = "$(readlink "${LATEST}")" ]; then
-        rm -f "${LATEST}"
-    fi
 fi

--- a/src/workflow/EasyCluster.cpp
+++ b/src/workflow/EasyCluster.cpp
@@ -53,13 +53,15 @@ int easycluster(int argc, const char **argv, const Command &command) {
 
     std::string tmpDir = par.filenames.back();
     std::string hash = SSTR(par.hashParameter(command.databases, par.filenames, *command.params));
+    std::string latest = tmpDir + "/latest";
     if (par.reuseLatest) {
-        hash = FileUtil::getHashFromSymLink(tmpDir + "/latest");
+        hash = FileUtil::getHashFromSymLink(latest);
     }
     tmpDir = FileUtil::createTemporaryDirectory(tmpDir, hash);
     par.filenames.pop_back();
 
     CommandCaller cmd;
+    cmd.addVariable("LATEST", latest.c_str());
     cmd.addVariable("TMP_PATH", tmpDir.c_str());
     cmd.addVariable("RESULTS", par.filenames.back().c_str());
     par.filenames.pop_back();

--- a/src/workflow/EasyLinclust.cpp
+++ b/src/workflow/EasyLinclust.cpp
@@ -58,13 +58,15 @@ int easylinclust(int argc, const char **argv, const Command &command) {
 
     std::string tmpDir = par.filenames.back();
     std::string hash = SSTR(par.hashParameter(command.databases, par.filenames, *command.params));
+    std::string latest = tmpDir + "/latest";
     if (par.reuseLatest) {
-        hash = FileUtil::getHashFromSymLink(tmpDir + "/latest");
+        hash = FileUtil::getHashFromSymLink(latest);
     }
     tmpDir = FileUtil::createTemporaryDirectory(tmpDir, hash);
     par.filenames.pop_back();
 
     CommandCaller cmd;
+    cmd.addVariable("LATEST", latest.c_str());
     cmd.addVariable("TMP_PATH", tmpDir.c_str());
     cmd.addVariable("RESULTS", par.filenames.back().c_str());
     par.filenames.pop_back();

--- a/src/workflow/EasyRbh.cpp
+++ b/src/workflow/EasyRbh.cpp
@@ -66,13 +66,15 @@ int easyrbh(int argc, const char **argv, const Command &command) {
 
     std::string tmpDir = par.filenames.back();
     std::string hash = SSTR(par.hashParameter(command.databases, par.filenames, *command.params));
+    std::string latest = tmpDir + "/latest";
     if (par.reuseLatest) {
-        hash = FileUtil::getHashFromSymLink(tmpDir + "/latest");
+        hash = FileUtil::getHashFromSymLink(latest);
     }
     tmpDir = FileUtil::createTemporaryDirectory(tmpDir, hash);
     par.filenames.pop_back();
 
     CommandCaller cmd;
+    cmd.addVariable("LATEST", latest.c_str());
     cmd.addVariable("TMP_PATH", tmpDir.c_str());
     cmd.addVariable("RESULTS", par.filenames.back().c_str());
     par.filenames.pop_back();

--- a/src/workflow/EasySearch.cpp
+++ b/src/workflow/EasySearch.cpp
@@ -86,13 +86,15 @@ int doeasysearch(int argc, const char **argv, const Command &command, bool linse
 
     std::string tmpDir = par.filenames.back();
     std::string hash = SSTR(par.hashParameter(command.databases, par.filenames, *command.params));
+    std::string latest = tmpDir + "/latest";
     if (par.reuseLatest) {
-        hash = FileUtil::getHashFromSymLink(tmpDir + "/latest");
+        hash = FileUtil::getHashFromSymLink(latest);
     }
     tmpDir = FileUtil::createTemporaryDirectory(tmpDir, hash);
     par.filenames.pop_back();
 
     CommandCaller cmd;
+    cmd.addVariable("LATEST", latest.c_str());
     cmd.addVariable("TMP_PATH", tmpDir.c_str());
     cmd.addVariable("RESULTS", par.filenames.back().c_str());
     par.filenames.pop_back();

--- a/src/workflow/EasyTaxonomy.cpp
+++ b/src/workflow/EasyTaxonomy.cpp
@@ -43,13 +43,15 @@ int easytaxonomy(int argc, const char **argv, const Command& command) {
 
     std::string tmpDir = par.filenames.back();
     std::string hash = SSTR(par.hashParameter(command.databases, par.filenames, *command.params));
+    std::string latest = tmpDir + "/latest";
     if (par.reuseLatest) {
-        hash = FileUtil::getHashFromSymLink(tmpDir + "/latest");
+        hash = FileUtil::getHashFromSymLink(latest);
     }
     tmpDir = FileUtil::createTemporaryDirectory(tmpDir, hash);
     par.filenames.pop_back();
 
     CommandCaller cmd;
+    cmd.addVariable("LATEST", latest.c_str());
     cmd.addVariable("RESULTS", par.filenames.back().c_str());
     par.filenames.pop_back();
     cmd.addVariable("TARGET", par.filenames.back().c_str());


### PR DESCRIPTION
* Modified workflow source codes to assign `latest` symbolic link to variable `$LATEST`
* Modified workflow shell scripts to remove hash-named temporary directory ~and symbolic link~ (concurrent modification issue)