### PR TITLE
spelling fixes

### DIFF
--- a/src/commons/CSProfile.cpp
+++ b/src/commons/CSProfile.cpp
@@ -87,7 +87,7 @@ void ContextLibrary::readContextProfile(std::stringstream &in, LibraryReader &re
     size_t nalph = reader.ReadInt(line.c_str(), "ALPH", "Unable to parse CRF state 'ALPH'!");
     if (nalph != 20){
         Debug(Debug::ERROR) << "Alphabet size of serialized CRF state should be 20 "
-                "but is acutally" << nalph << "!\n";
+                "but is actually" << nalph << "!\n";
         EXIT(EXIT_FAILURE);
     }
     // If everything went fine we can resize our data memmbers

--- a/src/workflow/Databases.cpp
+++ b/src/workflow/Databases.cpp
@@ -124,7 +124,7 @@ std::vector<DatabaseDownload> downloads = {{
                                                    { }
                                            }, {
                                                    "VOGDB",
-                                                   "VOGDB is a continously updated resource of Virus Orthologous Groups",
+                                                   "VOGDB is a continuously updated resource of Virus Orthologous Groups",
                                                    "Marz et al: Challenges in RNA virus bioinformatics. Bioinformatics 30, 1793–9 (2014)",
                                                    "https://vogdb.org",
                                                    false, Parameters::DBTYPE_HMM_PROFILE, databases_sh, databases_sh_len,


### PR DESCRIPTION
While packaging metaeuk for Debian, we noticed a number of small spelling mistakes in MMseqs2 code as well, by means of Debian's automated spellcheck tooling for binaries.