### PR TITLE
make it so that pairaln requires only .idx_mapping if .idx input is used

### DIFF
--- a/src/util/pairaln.cpp
+++ b/src/util/pairaln.cpp
@@ -38,8 +38,8 @@ int pairaln(int argc, const char **argv, const Command& command) {
         fileToIds[lookup[i].fileNumber].push_back(lookup[i].id);
     }
 
-    std::string db2NoIndexName = PrefilteringIndexReader::dbPathWithoutIndex(par.db2);
-    MappingReader* mapping = new MappingReader(db2NoIndexName);
+    std::string db2Name = par.db2;
+    MappingReader* mapping = new MappingReader(db2Name);
 
     DBReader<unsigned int> alnDbr(par.db3.c_str(), par.db3Index.c_str(), par.threads, DBReader<unsigned int>::USE_INDEX|DBReader<unsigned int>::USE_DATA);
     alnDbr.open(DBReader<unsigned int>::NOSORT);


### PR DESCRIPTION
Changes behavior of pairaln (regarding requirements of presence of taxonomy files) when .idx database is used as input. This makes it possible to run pairing with indexed db alone (db.idx, db.idx_taxonomy, db.idx_mapping), without other files.

**Previous behavior:**
search_db (no idx):
requires search_db_taxonomy

search_db.idx:
requires search_db_taxonomy
requires search_db.idx_taxonomy


**New behavior:**
search_db (no idx):
requires search_db_taxonomy

search_db.idx:
requires search_db.idx_taxonomy
