### PR TITLE
Patches to allow MMseqs2 to build with gcc13

### DIFF
--- a/src/commons/Debug.h
+++ b/src/commons/Debug.h
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <cstddef>
 #include <sys/stat.h>
+#include <cstdint>
 
 class TtyCheck {
 public:

--- a/src/commons/Parameters.h
+++ b/src/commons/Parameters.h
@@ -10,6 +10,7 @@
 #include <typeinfo>
 #include <cstddef>
 #include <utility>
+#include <cstdint>
 
 #include "Command.h"
 #include "MultiParam.h"

--- a/src/commons/Util.h
+++ b/src/commons/Util.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <limits>
 #include <map>
+#include <cstdint>
 #include "MMseqsMPI.h"
 
 #ifndef EXIT

--- a/src/prefiltering/Indexer.h
+++ b/src/prefiltering/Indexer.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <iostream>
+#include <cstdint>
 
 class Indexer{
     


### PR DESCRIPTION
Due to changes in the way it handles includes, `MMseqs2` wasn't building with `gcc13`. These 4 files required patching to make them behave ...