### PR TITLE
Fix database creation for GTDB r214

### DIFF
--- a/data/workflow/databases.sh
+++ b/data/workflow/databases.sh
@@ -373,7 +373,7 @@ case "${INPUT_TYPE}" in
         # shellcheck disable=SC2086
         "${MMSEQS}" tar2db "${TMP_PATH}/gtdb.tar.gz" "${TMP_PATH}/tardb" --tar-include 'faa.gz$' ${THREADS_PAR} \
             || fail "tar2db died"
-        sed 's|_protein\.faa||g' "${TMP_PATH}/tardb.lookup" > "${TMP_PATH}/tardb.lookup.tmp"
+        sed 's|_protein\.faa\.gz||g' "${TMP_PATH}/tardb.lookup" > "${TMP_PATH}/tardb.lookup.tmp"
         mv -f -- "${TMP_PATH}/tardb.lookup.tmp" "${TMP_PATH}/tardb.lookup"
         # shellcheck disable=SC2086
         "${MMSEQS}" createdb "${TMP_PATH}/tardb" "${OUTDB}" ${COMP_PAR} \

--- a/data/workflow/databases.sh
+++ b/data/workflow/databases.sh
@@ -371,7 +371,7 @@ case "${INPUT_TYPE}" in
     ;;
     "GTDB")
         # shellcheck disable=SC2086
-        "${MMSEQS}" tar2db "${TMP_PATH}/gtdb.tar.gz" "${TMP_PATH}/tardb" --tar-include 'faa$' ${THREADS_PAR} \
+        "${MMSEQS}" tar2db "${TMP_PATH}/gtdb.tar.gz" "${TMP_PATH}/tardb" --tar-include 'faa.gz$' ${THREADS_PAR} \
             || fail "tar2db died"
         sed 's|_protein\.faa||g' "${TMP_PATH}/tardb.lookup" > "${TMP_PATH}/tardb.lookup.tmp"
         mv -f -- "${TMP_PATH}/tardb.lookup.tmp" "${TMP_PATH}/tardb.lookup"

--- a/data/workflow/databases.sh
+++ b/data/workflow/databases.sh
@@ -136,7 +136,7 @@ case "${SELECTION}" in
     ;;
     "GTDB")
         if notExists "${TMP_PATH}/download.done"; then
-            downloadFile "https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/VERSION" "${TMP_PATH}/version"
+            downloadFile "https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/VERSION.txt" "${TMP_PATH}/version"
             downloadFile "https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/gtdb_proteins_aa_reps.tar.gz" "${TMP_PATH}/gtdb.tar.gz"
             downloadFile "https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/bac120_taxonomy.tsv" "${TMP_PATH}/bac120_taxonomy.tsv"
             downloadFile "https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/ar53_taxonomy.tsv" "${TMP_PATH}/ar53_taxonomy.tsv"


### PR DESCRIPTION
As mentioned in https://github.com/soedinglab/MMseqs2/issues/740, the protein FASTA files in GTDB r214 are now individually compressed. Because the `mmseqs tar2db` command only includes files that finish wirh `.faa`, the protein files are being ignored and the database is not being created.

This PR just changes [this line](https://github.com/soedinglab/MMseqs2/blob/ad6dfc66d7bbc4fd626fc19adf10ba587bc137c4/data/workflow/databases.sh#L374) to change `--tar-include 'faa$'` to `--tar-include 'faa.gz$'`.