### PR TITLE
Fix: using files.wwpdb.org instead of ftp.wwpdb.org 

### DIFF
--- a/data/workflow/databases.sh
+++ b/data/workflow/databases.sh
@@ -147,7 +147,7 @@ case "${SELECTION}" in
     "PDB")
         if notExists "${TMP_PATH}/pdb_seqres.txt.gz"; then
             date "+%s" > "${TMP_PATH}/version"
-            downloadFile "https://ftp.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt.gz" "${TMP_PATH}/pdb_seqres.txt.gz"
+            downloadFile "https://files.wwpdb.org/pub/pdb/derived_data/pdb_seqres.txt.gz" "${TMP_PATH}/pdb_seqres.txt.gz"
         fi
         push_back "${TMP_PATH}/pdb_seqres.txt.gz"
         INPUT_TYPE="FASTA_LIST"


### PR DESCRIPTION
Following #772: ftp.wwpdb.org is being deprecated. It does not accept http(s) requests anymore. Moving to the new FTP archive over HTTP service.