### PR TITLE
fix: prefilter segfault

### DIFF
--- a/src/prefiltering/UngappedAlignment.cpp
+++ b/src/prefiltering/UngappedAlignment.cpp
@@ -249,7 +249,7 @@ void UngappedAlignment::scoreDiagonalAndUpdateHits(const char * queryProfile,
                 // hack to avoid too long sequences
                 // this sequences will be processed by computeLongScore later
                 seqs[seqIdx].seq = (unsigned char *) tmp.first;
-                seqs[seqIdx].seqLen = 1;
+                seqs[seqIdx].seqLen = 0;
                 seqs[seqIdx].id = seqIdx;
             }else{
                 seqs[seqIdx].seq = (unsigned char *) tmp.first;
@@ -276,7 +276,7 @@ void UngappedAlignment::scoreDiagonalAndUpdateHits(const char * queryProfile,
             unsigned int minSeqLen = std::min(targetMaxLen - minDistToDiagonal, queryLen);
             for(size_t i = 0; i < DIAGONALBINSIZE; i++) {
                 tmpSeqs[i] = seqs[i].seq + minDistToDiagonal;
-                seqLength[i] = std::min(seqs[i].seqLen - minDistToDiagonal, minSeqLen);
+                seqLength[i] = (seqs[i].seqLen == 0) ? 0 : std::min(seqs[i].seqLen - minDistToDiagonal, minSeqLen);
             }
             unrolledDiagonalScoring<Sequence::PROFILE_AA_SIZE + 1>(queryProfile, seqLength,
                                                                    tmpSeqs, score_arr);
@@ -286,7 +286,7 @@ void UngappedAlignment::scoreDiagonalAndUpdateHits(const char * queryProfile,
         for(size_t hitIdx = 0; hitIdx < hitSize; hitIdx++){
             hits[seqs[hitIdx].id]->count = static_cast<unsigned char>(std::min(static_cast<unsigned int>(255),
                                                                                score_arr[hitIdx]));
-            if(seqs[hitIdx].seqLen == 1){
+            if(seqs[hitIdx].seqLen == 0){
                 std::pair<const unsigned char *, const unsigned int> dbSeq =  sequenceLookup->getSequence(hits[hitIdx]->id);
                 if(dbSeq.second >= 32768){
                     int max = computeLongScore(queryProfile, queryLen, dbSeq, diagonal);

--- a/src/prefiltering/UngappedAlignment.cpp
+++ b/src/prefiltering/UngappedAlignment.cpp
@@ -276,7 +276,7 @@ void UngappedAlignment::scoreDiagonalAndUpdateHits(const char * queryProfile,
             unsigned int minSeqLen = std::min(targetMaxLen - minDistToDiagonal, queryLen);
             for(size_t i = 0; i < DIAGONALBINSIZE; i++) {
                 tmpSeqs[i] = seqs[i].seq + minDistToDiagonal;
-                seqLength[i] = (seqs[i].seqLen == 0) ? 0 : std::min(seqs[i].seqLen - minDistToDiagonal, minSeqLen);
+                seqLength[i] = (seqs[i].seqLen > minDistToDiagonal) ? std::min(seqs[i].seqLen - minDistToDiagonal, minSeqLen) : 0;
             }
             unrolledDiagonalScoring<Sequence::PROFILE_AA_SIZE + 1>(queryProfile, seqLength,
                                                                    tmpSeqs, score_arr);


### PR DESCRIPTION
## Description
bugfix for a segmentation fault in `mmseqs prefilter`, which occured in the following circumstances:

- `seqLen` of sequences larger than `32768` are overridden to `1` to lower their priority in diagonal score calculation
- `min(seqs[i].seqLen - minDistToDiagonal, minSeqLen);` returns an underflowed value for low `seqLen`, which holds for the above case (`UngappedAlignment L:279`)

=> this invalid `seqLength` value causes `unrolledDiagonalScoring(...)` to access memory out of bounds, causing a seg fault

## Changes
- added a safety check to prevent `seqLength` having invalid(underflowed) values
- `seqLen` larger than `32768` are overridden to `0` instead of `1`, in order to completely skip the processing inside `unrolledDiagonalScoring(...)`

## Other Details
- error encountered when running mmseqs easy-cluster on uniparc DB
- stack trace:
```
#0  UngappedAlignment::unrolledDiagonalScoring<21u> (...) 
    at MMseqs2/src/prefiltering/UngappedAlignment.cpp:58
#1  UngappedAlignment::scoreDiagonalAndUpdateHits (...) 
    at MMseqs2/src/prefiltering/UngappedAlignment.cpp:281
#2  UngappedAlignment::computeScores (...) 
    at /MMseqs2/src/prefiltering/UngappedAlignment.cpp:349
#3  UngappedAlignment::align (...)
    at /MMseqs2/src/prefiltering/UngappedAlignment.cpp:26
#4  QueryMatcher::match (...)
    at /MMseqs2/src/prefiltering/QueryMatcher.cpp:295
#5  QueryMatcher::matchQuery (...)
    at /MMseqs2/src/prefiltering/QueryMatcher.cpp:103
#6  Prefiltering::runSplit (...)
    at /MMseqs2/src/prefiltering/Prefiltering.cpp:843
```