### PR TITLE
Use available cores count as default threads number

### DIFF
--- a/src/commons/Parameters.cpp
+++ b/src/commons/Parameters.cpp
@@ -2340,12 +2340,7 @@ void Parameters::setDefaults() {
     if (threadEnv != NULL) {
         threads = (int) Util::fast_atoi<unsigned int>(threadEnv);
     } else {
-        #ifdef _SC_NPROCESSORS_ONLN
-            threads = sysconf(_SC_NPROCESSORS_ONLN);
-        #endif
-        if(threads <= 1){
-            threads = Util::omp_thread_count();
-        }
+        threads = Util::omp_thread_count();
     }
 
 #endif


### PR DESCRIPTION
Use only Util::omp_thread_count() to get the number of accessible cores to the process and its children.

sysconf(_SC_NPROCESSORS_ONLN) gets the hardware core count that could be different if mmseqs2 is running within a constrained environmenet (taskset, cgroups, slurm...).

Resolve #925