### PR TITLE
Fix start coordinate in SAM

### DIFF
--- a/src/util/convertalignments.cpp
+++ b/src/util/convertalignments.cpp
@@ -716,7 +716,7 @@ int convertalignments(int argc, const char **argv, const Command &command) {
                         uint32_t mapq = -4.343 * log(exp(static_cast<double>(-rawScore)));
                         mapq = (uint32_t) (mapq + 4.99);
                         mapq = mapq < 254 ? mapq : 254;
-                        int count = snprintf(buffer, sizeof(buffer), "%s\t%d\t%s\t%d\t%d\t",  queryId.c_str(), (forward) ? 0 : 16, targetId.c_str(), res.dbStartPos + 1, mapq);
+                        int count = snprintf(buffer, sizeof(buffer), "%s\t%d\t%s\t%d\t%d\t",  queryId.c_str(), (forward) ? 0 : 16, targetId.c_str(), std::min(res.dbStartPos + 1, res.dbEndPos + 1), mapq);
                         if (count < 0 || static_cast<size_t>(count) >= sizeof(buffer)) {
                             Debug(Debug::WARNING) << "Truncated line in entry" << i << "!\n";
                             continue;


### PR DESCRIPTION
Addresses https://github.com/soedinglab/MMseqs2/issues/952

Not sure why I missed this line when opening the issue. Wasn't sure if we should take `min` of start and end or use `forward` to decide whether we take start or end. This seems to work. Thanks for your consideration!