### PR TITLE
Introduce simd_any()/simd_eq_all(), optimize simd_hmax*() for Armv8 Neon

### DIFF
--- a/lib/simd/simd.h
+++ b/lib/simd/simd.h
@@ -166,6 +166,7 @@ typedef __m512i simd_int;
 uint32_t simd_hmax32_sse(const __m128i buffer);
 uint16_t simd_hmax16_sse(const __m128i buffer);
 uint8_t simd_hmax8_sse(const __m128i buffer);
+bool simd_any_sse(const __m128i buffer);
 
 inline uint32_t simd_hmax32_avx(const __m256i buffer) {
     const __m128i abcd = _mm256_castsi256_si128(buffer);
@@ -189,6 +190,34 @@ inline uint8_t simd_hmax8_avx(const __m256i buffer) {
     const __m128i efgh = _mm256_extracti128_si256(buffer, 1);
     const uint8_t second = simd_hmax8_sse(efgh);
     return std::max(first, second);
+}
+
+inline bool simd_any_avx(const __m256i buffer) {
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    const __m128i lo = _mm256_castsi256_si128(buffer);
+    const __m128i hi = _mm256_extracti128_si256(buffer, 1);
+    const __m128i lo_or_hi = _mm_or_si128(lo, hi);
+    return simd_any_sse(lo_or_hi);
+#else
+    const __m256i vZero = _mm256_set1_epi32(0);
+    const __m256i vTemp = _mm256_cmpeq_epi8(buffer, vZero);
+    const uint32_t mask = _mm256_movemask_epi8(vTemp);
+    return (mask != 0xffffffff);
+#endif
+}
+
+inline bool simd_eq_all_avx(const __m256i a, const __m256i b) {
+    const __m256i vector_mask = _mm256_cmpeq_epi8(a, b);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    const __m128i lo = _mm256_castsi256_si128(vector_mask);
+    const __m128i hi = _mm256_extracti128_si256(vector_mask, 1);
+    const __m128i lo_and_hi = _mm_and_si128(lo, hi);
+    const uint32_t min_dword = vminvq_u32(vreinterpretq_u32_s64(lo_and_hi));
+    return (min_dword == 0xffffffff);
+#else
+    const uint32_t bit_mask = _mm256_movemask_epi8(vector_mask);
+    return (bit_mask == 0xffffffff);
+#endif
 }
 
 inline float simdf32_hadd(const __m256 x) {
@@ -250,6 +279,8 @@ typedef __m256i simd_int;
 #define simdi16_hmax(x)     simd_hmax16_avx(x)
 #define simdui8_max(x,y)    _mm256_max_epu8(x,y)
 #define simdi8_hmax(x)      simd_hmax8_avx(x)
+#define simd_any(x)         simd_any_avx(x)
+#define simd_eq_all(x,y)    simd_eq_all_avx(x,y)
 #define simdi_load(x)       _mm256_load_si256(x)
 #define simdf_load(x)       _mm256_load_ps(x)
 #define simdui8_avg(x,y)    _mm256_avg_epu8(x,y)
@@ -352,24 +383,59 @@ typedef __m256 simd_float;
 #include <simde/x86/sse4.1.h>
 // see https://stackoverflow.com/questions/6996764/fastest-way-to-do-horizontal-sse-vector-sum-or-other-reduction
 inline uint32_t simd_hmax32_sse(const __m128i buffer) {
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmaxvq_u32(vreinterpretq_u32_s64(buffer));
+#else
     __m128i hi64  = _mm_shuffle_epi32(buffer, _MM_SHUFFLE(1, 0, 3, 2));
     __m128i max64 = _mm_max_epi32(hi64, buffer);
     __m128i hi32  = _mm_shufflelo_epi16(max64, _MM_SHUFFLE(1, 0, 3, 2)); // Swap the low two elements
     __m128i max32 = _mm_max_epi32(max64, hi32);
     return _mm_cvtsi128_si32(max32); // SSE2 movd
+#endif
 }
 
 inline uint16_t simd_hmax16_sse(const __m128i buffer) {
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmaxvq_u16(vreinterpretq_u16_s64(buffer));
+#else
     __m128i tmp1 = _mm_subs_epu16(_mm_set1_epi16((short)65535), buffer);
     __m128i tmp3 = _mm_minpos_epu16(tmp1);
     return (65535 - _mm_cvtsi128_si32(tmp3));
+#endif
 }
 
 inline uint8_t simd_hmax8_sse(const __m128i buffer) {
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    return vmaxvq_u8(vreinterpretq_u8_s64(buffer));
+#else
     __m128i tmp1 = _mm_subs_epu8(_mm_set1_epi8((char)255), buffer);
     __m128i tmp2 = _mm_min_epu8(tmp1, _mm_srli_epi16(tmp1, 8));
     __m128i tmp3 = _mm_minpos_epu16(tmp2);
     return (int8_t)(255 -(int8_t) _mm_cvtsi128_si32(tmp3));
+#endif
+}
+
+inline bool simd_any_sse(const __m128i buffer) {
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    const uint32_t non_zero = vmaxvq_u32(vreinterpretq_u32_s64(buffer));
+    return static_cast<bool>(non_zero);
+#else
+    const __m128i vZero = _mm_set1_epi32(0);
+    const __m128i vTemp = _mm_cmpeq_epi8(buffer, vZero);
+    const uint32_t mask = _mm_movemask_epi8(vTemp);
+    return (mask != 0xffff);
+#endif
+}
+
+inline bool simd_eq_all_sse(const __m128i a, const __m128i b) {
+    const __m128i vector_mask = _mm_cmpeq_epi8(a, b);
+#if defined(SIMDE_ARM_NEON_A64V8_NATIVE)
+    const uint32_t min_dword = vminvq_u32(vreinterpretq_u32_s64(vector_mask));
+    return (min_dword == 0xffffffff);
+#else
+    const uint32_t bit_mask = _mm_movemask_epi8(vector_mask);
+    return (bit_mask == 0xffff);
+#endif
 }
 
 // see https://stackoverflow.com/questions/6996764/fastest-way-to-do-horizontal-sse-vector-sum-or-other-reduction
@@ -471,6 +537,8 @@ typedef __m128i simd_int;
 #define simdi16_hmax(x)     simd_hmax16_sse(x)
 #define simdui8_max(x,y)    _mm_max_epu8(x,y)
 #define simdi8_hmax(x)      simd_hmax8_sse(x)
+#define simd_any(x)         simd_any_sse(x)
+#define simd_eq_all(x,y)    simd_eq_all_sse(x,y)
 #define simdui8_avg(x,y)    _mm_avg_epu8(x,y)
 #define simdui16_avg(x,y)   _mm_avg_epu16(x,y)
 #define simdi_load(x)       _mm_load_si128(x)


### PR DESCRIPTION
Most of manually vectorized operations in StripedSmithWaterman.cpp are elementwise, and in such cases there is a single instruction emitted for both SSE/AVX and Neon, providing maximum performance on all the platforms.
But there are few places where in SSE/AVX case we need few instructions, and some of them don't have direct Neon equialent.
As a result, on Arm platform we have a long chain of Neon instructions exactly replicating what SSE/AVX instructions do, but what algorithm actually needs can be implemented with just a single Neon instruction.
A good example is existing simd_hmax8_sse() which returns maximum across vector.
For SSE it has 5 instructions:
```
inline uint8_t simd_hmax8_sse(const __m128i buffer) {
    __m128i tmp1 = _mm_subs_epu8(_mm_set1_epi8((char)255), buffer);  // psubusb
    __m128i tmp2 = _mm_min_epu8(tmp1, _mm_srli_epi16(tmp1, 8));      // psrlw, pminub
    __m128i tmp3 = _mm_minpos_epu16(tmp2);                           // phminposuw
    return (int8_t)(255 -(int8_t) _mm_cvtsi128_si32(tmp3));          // movd
}
```
Performant Neon implementation is just a single instruction:
```
inline uint8_t simd_hmax8_sse(const __m128i buffer) {
    return vmaxvq_u8(vreinterpretq_u8_s64(buffer));                  // umaxv
}
```

Proposal is to introduce additional simd_any()/simd_eq_all() functions similar to existing simd_hmax*() functions, which cover those non-elementwise operations.
And then, for simd_any()/simd_eq_all()/simd_hmax*(), have separate SSE/AVX and Neon implementations providing best performance on each platform.