### PR TITLE
Use comparison instead of unsigned int substraction

### DIFF
--- a/src/util/apply.cpp
+++ b/src/util/apply.cpp
@@ -149,7 +149,7 @@ int apply_by_entry(char* data, size_t size, unsigned int key, DBWriter& writer,
 
         if (plist[0].revents & POLLOUT) {
             ssize_t write_size = batch_size;
-            if (size - written > 0) {
+            if (size > written) {
                 for (;;) {
                     ssize_t w = write(fd[1], data + written, write_size);
                     if (w < 0) {


### PR DESCRIPTION
Static security scanner highlighted this line as a potential vulnerability, since both `size` and `written` are `size_t`, and hence can never be less than 0.

I don't believe it it an actual issue, but `size > written` should achieve the same goal.