### PR TITLE
Fix a compiler diagnostic with Clang 22

### DIFF
--- a/src/util/result2flat.cpp
+++ b/src/util/result2flat.cpp
@@ -62,7 +62,6 @@ int result2flat(int argc, const char **argv, const Command &command) {
             for(size_t  i = 0; i < DbValidator::resultDb.size(); i++){
                 if(Parameters::isEqualDbtype(dbr_data.getDbtype(), DbValidator::resultDb[i])  ) {
                     keyLen = (words[1] - words[0]);
-                    dbKeyBuffer.size();
                     dbKeyBuffer.append(words[0], keyLen);
                     const unsigned int dbKey = (unsigned int) strtoul(dbKeyBuffer.c_str(), NULL, 10);
                     target_header_data = targetdb_header.getDataByDBKey(dbKey, 0);


### PR DESCRIPTION
The code contains a call to std::string::size() as a statement on its own. The function doesn't have side effects, thus, the call is a no-op, which also triggers the -Wunused-result Clang diagnostic.