### PR TITLE
add include for thread in gpuserver.cpp

### DIFF
--- a/src/util/gpuserver.cpp
+++ b/src/util/gpuserver.cpp
@@ -9,6 +9,7 @@
 // #define HAVE_CUDA 1
 #ifdef HAVE_CUDA
 #include "GpuUtil.h"
+#include <thread>
 #endif
 
 #include <random>


### PR DESCRIPTION
Ran into an issue compiling with cuda support. It looks like 0eb3ca2f8d4329f95d18b86149a293c01bbc6595 pulled the `#include <thread>` from `GpuUtil.h`, there's a call to `std::this_thread::yield()` in `gpuserver.cpp` that needs that.