### PR TITLE
Enable GPU-accelerated translated search

### DIFF
--- a/data/workflow/translated_search.sh
+++ b/data/workflow/translated_search.sh
@@ -58,6 +58,14 @@ if [ -n "$NO_TARGET_INDEX" ]; then
     fi
     TARGET="${TMP_PATH}/t_orfs_aa"
     TARGET_ORF="${TMP_PATH}/t_orfs_aa"
+    if [ -n "$GPU" ]; then
+        if notExists "${TMP_PATH}/t_orfs_aa_pad.dbtype"; then
+            # shellcheck disable=SC2086
+            "$MMSEQS" makepaddedseqdb "${TMP_PATH}/t_orfs_aa" "${TMP_PATH}/t_orfs_aa_pad" ${MAKEPADDEDSEQDB_PAR} \
+                || fail "makepaddedseqdb target ORFs died"
+        fi
+        TARGET="${TMP_PATH}/t_orfs_aa_pad"
+    fi
 fi
 fi
 
@@ -96,6 +104,12 @@ if [ -n "$REMOVE_TMP" ]; then
     "$MMSEQS" rmdb "${TMP_PATH}/q_orfs_aa" ${VERBOSITY}
     # shellcheck disable=SC2086
     "$MMSEQS" rmdb "${TMP_PATH}/t_orfs_aa" ${VERBOSITY}
+    if [ -f "${TMP_PATH}/t_orfs_aa_pad.dbtype" ]; then
+        # shellcheck disable=SC2086
+        "$MMSEQS" rmdb "${TMP_PATH}/t_orfs_aa_pad" ${VERBOSITY}
+        # shellcheck disable=SC2086
+        "$MMSEQS" rmdb "${TMP_PATH}/t_orfs_aa_pad_h" ${VERBOSITY}
+    fi
     # shellcheck disable=SC2086
     "$MMSEQS" rmdb "${TMP_PATH}/aln" ${VERBOSITY}
     if [ -n "${REFERENCE_FILTER}" ]; then

--- a/src/workflow/Search.cpp
+++ b/src/workflow/Search.cpp
@@ -588,6 +588,8 @@ int search(int argc, const char **argv, const Command& command) {
         } else {
             cmd.addVariable("ORF_PAR", par.createParameterString(par.extractorfs).c_str());
         }
+        cmd.addVariable("GPU", par.gpu ? "TRUE" : NULL);
+        cmd.addVariable("MAKEPADDEDSEQDB_PAR", par.createParameterString(par.makepaddedseqdb).c_str());
         cmd.addVariable("SEARCH", program.c_str());
         program = std::string(tmpDir + "/translated_search.sh");
         FileUtil::writeFile(program.c_str(), translated_search_sh, translated_search_sh_len);


### PR DESCRIPTION
## Summary
- Pass `GPU` and `MAKEPADDEDSEQDB_PAR` environment variables from `Search.cpp` to the translated search workflow
- When GPU is enabled and the target database is nucleotide, automatically run `makepaddedseqdb` on the translated ORF database before the inner protein search
- Clean up the temporary padded database when `REMOVE_TMP` is set

This enables GPU acceleration for all three translated search modes: **blastx** (nucleotide query → protein target), **tblastn** (protein query → nucleotide target), and **tblastx** (nucleotide query → nucleotide target).

## Benchmark (1,000 queries × 10,000 targets, DGX Spark)

| Mode | GPU | CPU (ungapped) | Speedup |
|------|-----|---------------|---------|
| tblastx | 2.2s | 34.4s | **15.5×** |
| blastx | 3.7s | 64.2s | **17.4×** |

GPU and CPU produce identical results in all tested cases.

## Test plan
- [x] blastx (nucl→prot) with `--gpu 1`: verified GPU/CPU results identical
- [x] tblastn (prot→nucl) with `--gpu 1 --mask 0`: verified GPU/CPU results identical
- [x] tblastx (nucl→nucl) with `--gpu 1 --mask 0`: verified GPU/CPU results identical (6/6 hits match)
- [x] Large-scale benchmark: 1,000 × 10,000 sequences, hit counts match between GPU and CPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)