### PR TITLE
 Fix buffer overflow in k-mer prefilter with highly conserved sequences

### DIFF
--- a/src/prefiltering/CacheFriendlyOperations.cpp
+++ b/src/prefiltering/CacheFriendlyOperations.cpp
@@ -207,8 +207,8 @@ size_t CacheFriendlyOperations<BINSIZE>::findDuplicates(CounterResult *output, s
             duplicateBitArray[hashBinElement] = currDiagonal;
         }
         // check for overflow
-        if (doubleElementCount + std::min(elementCount, currBinSize/2) >= outputSize) {
-            return doubleElementCount;
+        if (doubleElementCount + elementCount >= outputSize) {
+                    return doubleElementCount;
         }
         // set memory to zero
         if (computeTotalScore) {


### PR DESCRIPTION
`CacheFriendlyOperations::findDuplicates` underestimates output size when checking for buffer overflow. The check uses `std::min(elementCount, currBinSize/2`), assuming at most half of bin entries are duplicates. This assumption breaks when query k-mers are shared across a large fraction of the target database — as it happens with antibody variable region sequences, where conserved framework k-mers match ~70% of targets on consistent diagonals.                                                                                                                                                                                          The result is silent out-of-bounds writes to the foundDiagonals buffer, causing segfaults during prefiltering. With multiple threads, the corruption typically crashes at low progress (~8%). 

To reproduce: run mmseqs easy-search with an antibody query against a multi-million antibody database (e.g. 10M clonotype sequences). Any dataset where conserved k-mers match a large fraction of targets will trigger it.                                                                                                  
                  
To fix: replace `std::min(elementCount, currBinSize/2)` with `elementCount` for a correct upper bound.