### PR TITLE
fix: add explicit thrust/tuple.h for CUDA 13 compatibility

### DIFF
--- a/lib/libmarv/src/cudasw4.cuh
+++ b/lib/libmarv/src/cudasw4.cuh
@@ -37,6 +37,7 @@
 #include <thrust/iterator/constant_iterator.h>
 #include <thrust/merge.h>
 #include <thrust/distance.h>
+#include <thrust/tuple.h>
 
 #include <iostream>
 #include <string>


### PR DESCRIPTION
## Summary

- Add `#include <thrust/tuple.h>` to `lib/libmarv/src/cudasw4.cuh`

CUDA 13 (CCCL refactor) reorganized Thrust's internal header dependencies. As a result, `thrust::get` is no longer implicitly available via `<thrust/sort.h>` or `<thrust/merge.h>`, causing a build failure:

```
namespace "thrust" has no member "get"
    const auto scoreL = thrust::get<0>(lhs);
```

The fix adds an explicit `#include <thrust/tuple.h>` which is backward compatible with all CUDA versions ≥ 7.

## Test plan

- [x] Verified build succeeds on CUDA 13.4 (DGX Spark, sm_120, aarch64)
- [x] Confirmed master branch fails with the same error without this fix
- [x] `<thrust/tuple.h>` has existed since Thrust 1.x — no regression on older CUDA versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)